### PR TITLE
feat: implement admin authentication guard, secure admin endpoints, a…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "cookie-parser": "^1.4.7",
         "mongoose": "^8.16.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
@@ -31,6 +32,7 @@
         "@swc/cli": "^0.6.0",
         "@swc/core": "^1.10.7",
         "@types/bcrypt": "^5.0.2",
+        "@types/cookie-parser": "^1.4.9",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.7",
@@ -3307,6 +3309,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -5725,6 +5737,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "cookie-parser": "^1.4.7",
     "mongoose": "^8.16.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
@@ -42,6 +43,7 @@
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
     "@types/bcrypt": "^5.0.2",
+    "@types/cookie-parser": "^1.4.9",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",

--- a/src/guard/admin-auth.guard.ts
+++ b/src/guard/admin-auth.guard.ts
@@ -1,0 +1,31 @@
+import {CanActivate, ExecutionContext, ForbiddenException, Injectable} from '@nestjs/common';
+import {AuthService} from '../modules/auth/auth.service';
+
+@Injectable()
+export class AdminAuthGuard implements CanActivate {
+    constructor(private readonly authService: AuthService) {
+    }
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const request = context.switchToHttp().getRequest();
+        const token = request.cookies['accessToken'];
+
+        if (!token) {
+            throw new ForbiddenException('User not authenticated');
+        }
+
+        const payload = await this.authService.verifyAccessToken(token);
+
+        const userId = payload?.sub || payload?._id;
+        if (!userId) {
+            throw new ForbiddenException('User not authenticated');
+        }
+
+        const user = await this.authService.getUserById(userId);
+        if (!user || user.role !== 'AppAdmin') {
+            throw new ForbiddenException('Access denied');
+        }
+        return true;
+    }
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,26 @@
 import {NestFactory} from '@nestjs/core';
 import {AppModule} from './app.module';
 import {ValidationPipe} from "@nestjs/common";
+import * as cookieParser from "cookie-parser";
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
 
-    app.enableCors({
-        origin: '*',
-        methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
-        credentials: true,
-    });
+    const allowedOrigins = (process.env.ALLOWED_ORIGINS || "").split(",");
+    app.enableCors(
+        {
+            origin: (origin: string, callback: any) => {
+                if (!origin || allowedOrigins.indexOf(origin) !== -1) {
+                    callback(null, true);
+                } else {
+                    callback(new Error("Not allowed by CORS"));
+                }
+            },
+            methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+            credentials: true,
+        }
+    )
+    app.use(cookieParser());
 
     app.useGlobalPipes(
         new ValidationPipe({

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,4 +1,5 @@
-import {Body, Controller, Post} from '@nestjs/common';
+import {Body, Controller, Post, Res} from '@nestjs/common';
+import {Response} from 'express';
 import {AuthService} from './auth.service';
 import {LoginDto, SignupDto} from './dto/auth.dto';
 
@@ -8,12 +9,16 @@ export class AuthController {
     }
 
     @Post('signup')
-    async signup(@Body() data: SignupDto) {
-        return this.authService.signup(data);
+    async signup(@Body() data: SignupDto, @Res({passthrough: true}) res: Response) {
+        const resData = await this.authService.signup(data);
+        res.cookie('accessToken', resData.accessToken, {httpOnly: true, secure: false, sameSite: 'lax'});
+        return resData;
     }
 
     @Post('login')
-    async login(@Body() data: LoginDto) {
-        return this.authService.login(data);
+    async login(@Body() data: LoginDto, @Res({passthrough: true}) res: Response) {
+        const resData = await this.authService.login(data);
+        res.cookie('accessToken', resData.accessToken, {httpOnly: true, secure: false, sameSite: 'lax'});
+        return resData;
     }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,10 +1,11 @@
-import {Module} from '@nestjs/common';
+import {Global, Module} from '@nestjs/common';
 import {MongooseModule} from '@nestjs/mongoose';
 import {JwtModule} from '@nestjs/jwt';
 import {AuthController} from './auth.controller';
 import {AuthService} from './auth.service';
 import {User, UserSchema} from './schemas/user.schema';
 
+@Global()
 @Module({
     imports: [
         MongooseModule.forFeature([{name: User.name, schema: UserSchema}]),
@@ -17,6 +18,7 @@ import {User, UserSchema} from './schemas/user.schema';
     ],
     controllers: [AuthController],
     providers: [AuthService],
+    exports: [AuthService]
 })
 export class AuthModule {
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,107 +1,118 @@
-import {
-  BadRequestException,
-  HttpException,
-  HttpStatus,
-  Injectable,
-} from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
-import { User, UserDocument } from './schemas/user.schema';
-import { LoginDto, SignupDto } from './dto/auth.dto';
+import {BadRequestException, HttpException, HttpStatus, Injectable,} from '@nestjs/common';
+import {JwtService} from '@nestjs/jwt';
+import {User, UserDocument} from './schemas/user.schema';
+import {LoginDto, SignupDto} from './dto/auth.dto';
 import * as bcrypt from 'bcrypt';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import {InjectModel} from '@nestjs/mongoose';
+import {Model} from 'mongoose';
 
 @Injectable()
 export class AuthService {
-  constructor(
-    @InjectModel(User.name)
-    private readonly userModel: Model<UserDocument>,
-    private readonly jwtService: JwtService,
-  ) {}
-
-  generateAccessToken(user: UserDocument) {
-    return {
-      accessToken: this.jwtService.sign({
-        sub: user._id,
-        email: user.email,
-      }),
-    };
-  }
-
-  async hashPassword(password: string): Promise<string> {
-    return await bcrypt.hash(password, 12);
-  }
-
-  async signup(data: SignupDto) {
-    try {
-      const existingUser = await this.userModel.find();
-
-      if (existingUser.length) {
-        throw new BadRequestException({
-          message: 'Only one user can signup',
-        });
-      }
-
-      const hashedPassword = await this.hashPassword(data.password);
-
-      const newUser = await this.userModel.create({
-        ...data,
-        password: hashedPassword,
-      });
-
-      return {
-        user: Object.assign(newUser, { password: undefined }),
-      };
-    } catch (error) {
-      throw new HttpException(
-        {
-          status: error?.status || HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error?.response?.error,
-          message: error?.message,
-        },
-        error?.status || HttpStatus.INTERNAL_SERVER_ERROR,
-      );
+    constructor(
+        @InjectModel(User.name)
+        private readonly userModel: Model<UserDocument>,
+        private readonly jwtService: JwtService,
+    ) {
     }
-  }
 
-  async login(data: LoginDto) {
-    try {
-      const user = await this.userModel.findOne({ email: data.email });
-
-      if (!user) {
-        throw new BadRequestException({
-          message: 'Invalid credentials',
-        });
-      }
-
-      const isPasswordValid = await bcrypt.compare(
-        data.password,
-        user.password,
-      );
-
-      if (!isPasswordValid) {
-        throw new BadRequestException({
-          message: 'Invalid credentials',
-        });
-      }
-
-      const { accessToken } = this.generateAccessToken(user);
-
-      await user.save();
-
-      return {
-        user: Object.assign(user, { password: undefined, tokens: undefined }),
-        accessToken,
-      };
-    } catch (error) {
-      throw new HttpException(
-        {
-          status: error?.status || HttpStatus.INTERNAL_SERVER_ERROR,
-          error: error?.response?.error,
-          message: error?.message,
-        },
-        error?.status || HttpStatus.INTERNAL_SERVER_ERROR,
-      );
+    generateAccessToken(user: UserDocument) {
+        return {
+            accessToken: this.jwtService.sign({
+                sub: user._id,
+                email: user.email,
+            }),
+        };
     }
-  }
+
+    verifyAccessToken(token: string) {
+        try {
+            return this.jwtService.verify(token);
+        } catch {
+            return null;
+        }
+    }
+
+
+    async hashPassword(password: string): Promise<string> {
+        return await bcrypt.hash(password, 12);
+    }
+
+    async signup(data: SignupDto) {
+        try {
+            const existingUser = await this.userModel.findOne({email: data.email});
+            if (existingUser) {
+                throw new BadRequestException({
+                    message: 'User with this email already exists',
+                });
+            }
+
+            const hashedPassword = await this.hashPassword(data.password);
+
+            const newUser = await this.userModel.create({
+                ...data,
+                password: hashedPassword,
+            });
+
+            const {accessToken} = this.generateAccessToken(newUser);
+
+            return {
+                user: Object.assign(newUser, {password: undefined}),
+                accessToken
+            };
+        } catch (error) {
+            throw new HttpException(
+                {
+                    status: error?.status || HttpStatus.INTERNAL_SERVER_ERROR,
+                    error: error?.response?.error,
+                    message: error?.message,
+                },
+                error?.status || HttpStatus.INTERNAL_SERVER_ERROR,
+            );
+        }
+    }
+
+    async login(data: LoginDto) {
+        try {
+            const user = await this.userModel.findOne({email: data.email});
+
+            if (!user) {
+                throw new BadRequestException({
+                    message: 'Invalid credentials',
+                });
+            }
+
+            const isPasswordValid = await bcrypt.compare(
+                data.password,
+                user.password,
+            );
+
+            if (!isPasswordValid) {
+                throw new BadRequestException({
+                    message: 'Invalid credentials',
+                });
+            }
+
+            const {accessToken} = this.generateAccessToken(user);
+
+            await user.save();
+
+            return {
+                user: Object.assign(user, {password: undefined, tokens: undefined}),
+                accessToken,
+            };
+        } catch (error) {
+            throw new HttpException(
+                {
+                    status: error?.status || HttpStatus.INTERNAL_SERVER_ERROR,
+                    error: error?.response?.error,
+                    message: error?.message,
+                },
+                error?.status || HttpStatus.INTERNAL_SERVER_ERROR,
+            );
+        }
+    }
+
+    async getUserById(userId: string): Promise<UserDocument | null> {
+        return this.userModel.findById(userId);
+    }
 }

--- a/src/modules/auth/schemas/user.schema.ts
+++ b/src/modules/auth/schemas/user.schema.ts
@@ -10,6 +10,9 @@ export class User extends Document {
 
   @Prop({ required: true })
   password: string;
+
+  @Prop({ default: 'User' })
+  role: string;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);

--- a/src/modules/category/category.controller.ts
+++ b/src/modules/category/category.controller.ts
@@ -1,4 +1,4 @@
-import {Body, Controller, Delete, Get, Param, Patch, Post, Query} from '@nestjs/common';
+import {Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards} from '@nestjs/common';
 import {
     CreateCategoryDto,
     DeleteCategoryDto,
@@ -7,12 +7,14 @@ import {
     UpdateCategoryDto
 } from './dto/category.dto';
 import {CategoryService} from './category.service';
+import {AdminAuthGuard} from "../../guard/admin-auth.guard";
 
 @Controller('category')
 export class CategoryController {
     constructor(private readonly categoryService: CategoryService) {
     }
 
+    @UseGuards(AdminAuthGuard)
     @Post()
     async createCategory(@Body() createCategoryDto: CreateCategoryDto) {
         return this.categoryService.createCategory(createCategoryDto);
@@ -28,11 +30,13 @@ export class CategoryController {
         return this.categoryService.getAllCategories(query);
     }
 
+    @UseGuards(AdminAuthGuard)
     @Delete(':id')
     async deleteCategory(@Param() params: DeleteCategoryDto) {
         return this.categoryService.deleteCategory(params);
     }
 
+    @UseGuards(AdminAuthGuard)
     @Patch()
     async updateCategory(@Body() updateCategoryDto: UpdateCategoryDto) {
         return this.categoryService.updateCategory(updateCategoryDto);

--- a/src/modules/question/question.controller.ts
+++ b/src/modules/question/question.controller.ts
@@ -1,4 +1,4 @@
-import {Body, Controller, Delete, Get, Param, Patch, Post, Query} from '@nestjs/common';
+import {Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards} from '@nestjs/common';
 import {QuestionService} from './question.service';
 import {
     CreateQuestionDto,
@@ -7,12 +7,14 @@ import {
     GetQuestionDto,
     UpdateQuestionDto,
 } from './dto/question.dto';
+import {AdminAuthGuard} from "../../guard/admin-auth.guard";
 
 @Controller('question')
 export class QuestionController {
     constructor(private readonly questionService: QuestionService) {
     }
 
+    @UseGuards(AdminAuthGuard)
     @Post()
     async create(@Body() createQuestionDto: CreateQuestionDto) {
         return this.questionService.create(createQuestionDto);
@@ -28,11 +30,13 @@ export class QuestionController {
         return this.questionService.findOne(data);
     }
 
+    @UseGuards(AdminAuthGuard)
     @Patch()
     async update(@Body() updateQuestionDto: UpdateQuestionDto) {
         return this.questionService.update(updateQuestionDto);
     }
 
+    @UseGuards(AdminAuthGuard)
     @Delete(':id')
     async remove(@Param() data: DeleteQuestionDto) {
         return this.questionService.remove(data);

--- a/src/modules/quiz/quiz.controller.ts
+++ b/src/modules/quiz/quiz.controller.ts
@@ -1,33 +1,38 @@
-import {Controller, Post, Get, Patch, Delete, Param, Body, Query} from '@nestjs/common';
-import { QuizService } from './quiz.service';
-import {CreateQuizDto, UpdateQuizDto, GetQuizDto, DeleteQuizDto, GetAllQuizDto} from './dto/quiz.dto';
+import {Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards} from '@nestjs/common';
+import {QuizService} from './quiz.service';
+import {CreateQuizDto, DeleteQuizDto, GetAllQuizDto, GetQuizDto, UpdateQuizDto} from './dto/quiz.dto';
+import {AdminAuthGuard} from "../../guard/admin-auth.guard";
 
 @Controller('quiz')
 export class QuizController {
-  constructor(private readonly quizService: QuizService) {}
+    constructor(private readonly quizService: QuizService) {
+    }
 
-  @Post()
-  async create(@Body() createQuizDto: CreateQuizDto) {
-    return this.quizService.create(createQuizDto);
-  }
+    @UseGuards(AdminAuthGuard)
+    @Post()
+    async create(@Body() createQuizDto: CreateQuizDto) {
+        return this.quizService.create(createQuizDto);
+    }
 
-  @Get()
-  async findAll(@Query() query: GetAllQuizDto) {
-    return this.quizService.findAll(query);
-  }
+    @Get()
+    async findAll(@Query() query: GetAllQuizDto) {
+        return this.quizService.findAll(query);
+    }
 
-  @Get(':id')
-  async findOne(@Param() data: GetQuizDto) {
-    return this.quizService.findOne(data);
-  }
+    @Get(':id')
+    async findOne(@Param() data: GetQuizDto) {
+        return this.quizService.findOne(data);
+    }
 
-  @Patch()
-  async update(@Body() updateQuizDto: UpdateQuizDto) {
-    return this.quizService.update(updateQuizDto);
-  }
+    @UseGuards(AdminAuthGuard)
+    @Patch()
+    async update(@Body() updateQuizDto: UpdateQuizDto) {
+        return this.quizService.update(updateQuizDto);
+    }
 
-  @Delete(':id')
-  async remove(@Param() data: DeleteQuizDto) {
-    return this.quizService.remove(data);
-  }
+    @UseGuards(AdminAuthGuard)
+    @Delete(':id')
+    async remove(@Param() data: DeleteQuizDto) {
+        return this.quizService.remove(data);
+    }
 }


### PR DESCRIPTION
…nd add cookie-based JWT auth

- Add AdminAuthGuard for role-based admin access control
- Protect quiz, question, and category mutation endpoints with AdminAuthGuard
- Set JWT access token as httpOnly cookie on login and signup
- Add cookie-parser middleware and update CORS to support allowed origins from env
- Make AuthService global and exportable for guard usage
- Add role field to user schema with default 'User'
- Update dependencies to include cookie-parser and types